### PR TITLE
Durchschnitts Läufe implementiert

### DIFF
--- a/src/p030/Problem30.java
+++ b/src/p030/Problem30.java
@@ -49,4 +49,9 @@ public class Problem30 implements IProblem {
 
         return sum;
     }
+
+    @Override
+    public int getIterations() {
+        return 30;
+    }
 }

--- a/src/util/IProblem.java
+++ b/src/util/IProblem.java
@@ -3,4 +3,8 @@ package util;
 public interface IProblem {
 
     String solve();
+
+    default int getIterations() {
+        return 1;
+    }
 }

--- a/src/util/TestEuler.java
+++ b/src/util/TestEuler.java
@@ -1,5 +1,12 @@
 package util;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Triple;
 import p030.Problem30;
 
 public class TestEuler {
@@ -7,9 +14,41 @@ public class TestEuler {
     public static void main(final String[] args) {
 
         final Runtime rt = Runtime.getRuntime();
-        final long memory1 = rt.totalMemory() - rt.freeMemory();
 
         final IProblem problem = new Problem30();
+
+        final int iterations = problem.getIterations();
+        final String averageString = iterations > 1 ? "Average " : "";
+
+        final List<Long> timeList = new ArrayList<>(iterations);
+        final List<Double> ramList = new ArrayList<>(iterations);
+        final Set<String> lsgSet = new HashSet<>();
+
+        for (int i = 0; i < iterations; ++i) {
+            final Triple<Long, Double, String> metrics = TestEuler.solveProblemWithMetrics(problem, rt);
+            timeList.add(metrics.getLeft());
+            ramList.add(metrics.getMiddle());
+            lsgSet.add(metrics.getRight());
+        }
+
+        final List<String> oneEntry = new ArrayList<>();
+        oneEntry.addAll(lsgSet);
+
+        if (oneEntry.size() == 1) {
+            System.out.println(oneEntry.get(0));
+        } else if (oneEntry.size() > 1) {
+            System.out.println(oneEntry.get(0) + " Es gab mehrere Ergebnisse");
+        } else {
+            System.out.println("Es gab kein Ergebnis");
+        }
+
+        System.out.println(averageString + "Time in Millis: " + timeList.stream().collect(Collectors.averagingLong(Long::longValue)));
+        System.out.println(averageString + "Used RAM: " + ramList.stream().collect(Collectors.averagingDouble(Double::doubleValue)) + " MB");
+    }
+
+    public static Triple<Long, Double, String> solveProblemWithMetrics(final IProblem problem, final Runtime rt) {
+
+        final long memory1 = rt.totalMemory() - rt.freeMemory();
 
         final long zeit1 = System.currentTimeMillis();
 
@@ -18,11 +57,8 @@ public class TestEuler {
         final long zeit2 = System.currentTimeMillis();
         final long memory2 = rt.totalMemory() - rt.freeMemory();
 
-        System.out.println(lsg);
-        System.out.println("Time in Millis: " + (zeit2 - zeit1));
-
         final double usedRam = (memory2 - memory1) / 1000000.0;
 
-        System.out.println("Used RAM: " + usedRam + " MB");
+        return new ImmutableTriple<>(zeit2 - zeit1, usedRam, lsg);
     }
 }


### PR DESCRIPTION
Man kann jetzt ein Problem eine getIterations Methode überschreiben
lassen. Damit kann man steuern wie oft dieses Problem hintereinander
ausgeführt werden soll. Somit werden die dafür benötigten Zeiten und der
dafür benötigte Speicher in deren Werten präziser.